### PR TITLE
Fixed auto-friend add issue not being compatible with api

### DIFF
--- a/lib/src/retroshare.dart
+++ b/lib/src/retroshare.dart
@@ -536,19 +536,21 @@ class RsIdentity {
     return null;
   }
 
-  static Future<bool> setAutoAddFriendIdsAsContact(
+  static Future<void> setAutoAddFriendIdsAsContact(
     bool enabled,
     AuthToken authToken,
   ) async {
     const mPath = '/rsIdentity/setAutoAddFriendIdsAsContact';
 
-    final response = await rsApiCall(
+    // if the rsApi call was a success
+    // In case of failure, automatically exception will be thrown.
+    // No need to check for boolean values here, since 
+    // in case of 200, empty response body is being sent.
+    await rsApiCall(
       mPath,
       authToken: authToken,
       params: {'enabled': enabled},
     );
-
-    return response['retval'];
   }
 
   /// Update identity data (name, avatar...)


### PR DESCRIPTION
Previously it was expected for the endpoint `/rsIdentity/setAutoAddFriendIdsAsContact` to return a response payload containing the key `retval` in case of **200**.

However, now it returns an empty response in case of **200**, and thereby the original method is failing. So, updated the method here.